### PR TITLE
Implement full `vscode.TextDocument` mock in document service

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,31 +264,31 @@ const token = await getScopeInformationAtPosition(document, position);
 
 #### `getScopeInformationAtPosition`
 
-`getScopeInformationAtPosition(document: LiteTextDocument, position: vscode.Position): Promise<TextmateToken>`
+`getScopeInformationAtPosition(document: vscode.TextDocument, position: vscode.Position): Promise<TextmateToken>`
 
 Get token scope information at a specific position (caret line and character number).
 
-- **Parameter:** *document* - Document to be tokenized (`LiteTextDocument`).
+- **Parameter:** *document* - Document to be tokenized (`vscode.TextDocument`).
 - **Parameter:** *position* - Zero-indexed caret position of token in document (`vscode.Position`).
 - **Returns:** Promise resolving to token data for scope selected by caret position (`{Promise<TextmateToken>}`).
 
 #### `getScopeRangeAtPosition`
 
-`getScopeRangeAtPosition(document: LiteTextDocument, position: vscode.Position): vscode.Range;`
+`getScopeRangeAtPosition(document: vscode.TextDocument, position: vscode.Position): vscode.Range;`
 
 Get matching scope range of the Textmate token intersecting a caret position.
 
-- **Parameter:** *document* - Document to be tokenized (`LiteTextDocument`).
+- **Parameter:** *document* - Document to be tokenized (`vscode.TextDocument`).
 - **Parameter:** *position* - Zero-indexed caret position to intersect with (`vscode.Position`).
 - **Returns:** Promise resolving to character and line number of the range (`Promise<vscode.Range>`).
 
 #### `getTokenInformationAtPosition`
 
-`getTokenInformationAtPosition(document: LiteTextDocument, position: vscode.Position): Promise<vscode.TokenInformation>;`
+`getTokenInformationAtPosition(document: vscode.TextDocument, position: vscode.Position): Promise<vscode.TokenInformation>;`
 
 VS Code compatible performant API for token information at a caret position.
 
-- **Parameter:** *document* - Document to be tokenized (`LiteTextDocument`).
+- **Parameter:** *document* - Document to be tokenized (`vscode.TextDocument`).
 - **Parameter:** *position* - Zero-indexed caret position of token in document (`vscode.Position`).
 - **Returns:** Promise resolving to token data compatible with VS Code (`Promise<vscode.TokenInformation>`).
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -5,7 +5,6 @@ import * as vscode from 'vscode';
 import { GeneratorService } from './services/generators';
 import { TextmateScopeSelector } from './util/selectors';
 import { ContributorData } from './util/contributes';
-import type { LiteTextDocument } from './services/document';
 import type { TextmateToken } from './services/tokenizer';
 import type { GrammarLanguageDefinition, LanguageDefinition } from './util/contributes';
 
@@ -19,11 +18,11 @@ const contributorData = new ContributorData();
 
 /**
  * Get token scope information at a specific position (caret line and character number).
- * @param {LiteTextDocument} document Document to be tokenized.
+ * @param {vscode.TextDocument} document Document to be tokenized.
  * @param {vscode.Position} position Zero-indexed caret position of token in document.
  * @returns {Promise<TextmateToken>} Promise resolving to token data for scope selected by caret position.
  */
-export async function getScopeInformationAtPosition(document: LiteTextDocument, position: vscode.Position): Promise<TextmateToken> {
+export async function getScopeInformationAtPosition(document: vscode.TextDocument, position: vscode.Position): Promise<TextmateToken> {
 	const generator = await generators.fetch(document.languageId);
 	const tokenService = await generator.initTokenService();
 	const tokens = await tokenService.fetch(document);
@@ -33,11 +32,11 @@ export async function getScopeInformationAtPosition(document: LiteTextDocument, 
 
 /**
  * VS Code compatible performant API for token information at a caret position.
- * @param {LiteTextDocument} document Document to be tokenized.
+ * @param {vscode.TextDocument} document Document to be tokenized.
  * @param {vscode.Position} position Zero-indexed caret position of token in document.
  * @returns {Promise<vscode.TokenInformation>} Promise resolving to token data compatible with VS Code.
  */
-export async function getTokenInformationAtPosition(document: LiteTextDocument, position: vscode.Position): Promise<vscode.TokenInformation> {
+export async function getTokenInformationAtPosition(document: vscode.TextDocument, position: vscode.Position): Promise<vscode.TokenInformation> {
 	const caret = await getScopeInformationAtPosition(document, position);
 	const range = new vscode.Range(caret.line, caret.startIndex, caret.line, caret.endIndex);
 	const type = getTokenTypeFromScope(caret.scopes);
@@ -46,11 +45,11 @@ export async function getTokenInformationAtPosition(document: LiteTextDocument, 
 
 /**
  * Get matching scope range of the Textmate token intersecting a caret position.
- * @param {LiteTextDocument} document Document to be tokenized.
+ * @param {vscode.TextDocument} document Document to be tokenized.
  * @param {vscode.Position} position Zero-indexed caret position to intersect with.
  * @returns {Promise<vscode.Range>} Promise resolving to character and line number of the range.
  */
-export async function getScopeRangeAtPosition(document: LiteTextDocument, position: vscode.Position): Promise<vscode.Range> {
+export async function getScopeRangeAtPosition(document: vscode.TextDocument, position: vscode.Position): Promise<vscode.Range> {
 	const caret = await getScopeInformationAtPosition(document, position);
 	const range = new vscode.Range(caret.line, caret.startIndex, caret.line, caret.endIndex);
 	return range;

--- a/src/document-symbol.ts
+++ b/src/document-symbol.ts
@@ -2,7 +2,6 @@
 
 import * as vscode from 'vscode';
 import type { OutlineService, OutlineEntry } from './services/outline';
-import type { LiteTextDocument } from './services/document';
 
 interface LanguageSymbol {
 	readonly children: vscode.DocumentSymbol[];
@@ -13,12 +12,12 @@ interface LanguageSymbol {
 export class TextmateDocumentSymbolProvider implements vscode.DocumentSymbolProvider {
 	constructor(private _outlineService: OutlineService) {}
 
-	public async provideDocumentSymbolInformation(document: LiteTextDocument): Promise<vscode.SymbolInformation[]> {
+	public async provideDocumentSymbolInformation(document: vscode.TextDocument): Promise<vscode.SymbolInformation[]> {
 		const outline = await this._outlineService.fetch(document);
 		return outline.map(this.toSymbolInformation.bind(outline) as typeof this.toSymbolInformation, outline);
 	}
 
-	public async provideDocumentSymbols(document: LiteTextDocument): Promise<vscode.DocumentSymbol[]> {
+	public async provideDocumentSymbols(document: vscode.TextDocument): Promise<vscode.DocumentSymbol[]> {
 		const outline = await this._outlineService.fetch(document);
 		const root: LanguageSymbol = {
 			children: [],

--- a/src/services/document.ts
+++ b/src/services/document.ts
@@ -1,3 +1,7 @@
+/* --------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ * -------------------------------------------------------------------------------------------*/
 'use strict';
 
 import * as vscode from 'vscode';
@@ -5,38 +9,281 @@ import { readFileText } from '../util/loader';
 import { Disposable } from '../util/dispose';
 
 import type { ConfigData } from '../config';
-import { ResolverService } from './resolver';
-import { getOniguruma } from '../util/oniguruma';
+import { ContributorData } from '../util/contributes';
 
-const onigLibPromise = getOniguruma();
-const resolver = new ResolverService(onigLibPromise);
+const contributorData = new ContributorData();
 
-export interface LiteTextLine {
-	text: string;
+const _languageId2WordDefinition = new Map<string, RegExp>();
+export function setWordDefinitionFor(languageId: string, wordDefinition: RegExp): void {
+	if (!wordDefinition) {
+		_languageId2WordDefinition.delete(languageId);
+	} else {
+		_languageId2WordDefinition.set(languageId, wordDefinition);
+	}
 }
 
-export interface LiteTextDocument {
-	readonly uri: vscode.Uri;
-	readonly version: number;
-	readonly lineCount: number;
-	readonly languageId: string;
+function getWordDefinitionFor(languageId: string): RegExp | undefined {
+	return _languageId2WordDefinition.get(languageId);
+}
 
-	lineAt(line: number): LiteTextLine;
-	getText(): string;
+const defaultWordPattern = /-?\d*\.\d\w*|[^\`\~\!\@\#\$\%\^\&\*\(\)\-\=\+\[\{\]\}\\\|\;\:\'\"\,\.\<\>\/\?\s]+/;
+
+const EolMap = {
+	'\n': vscode.EndOfLine.LF,
+	'\r\n': vscode.EndOfLine.CRLF
+};
+
+export class FullTextDocument implements vscode.TextDocument {
+	private _eol: vscode.EndOfLine;
+	private _fileName: string;
+	private _isClosed: boolean;
+	private _isDirty: boolean;
+	private _isUntitled: boolean;
+	private _languageId: string;
+	private _lineCount: number;
+	private _uri: vscode.Uri;
+	private _version: number;
+	private _lines: vscode.TextLine[];
+	private _content: string;
+	private _lineOffsets: any;
+
+	constructor(uri: vscode.Uri, languageId: string, content: string) {
+		this._lines = [];
+
+		const parts = content.split(/(\r?\n)/);
+
+		const endOfLine = EolMap[parts[1]] || vscode.EndOfLine.LF;
+		const lineCount = Math.floor(parts.length / 2) + 1;
+
+		for (let lineNumber = 0; lineNumber < lineCount; lineNumber++) {
+			const text = parts[lineNumber * 2];
+			const ws = parts[lineNumber * 2 + 1];
+
+			const start = new vscode.Position(lineNumber, 0);
+			const end = new vscode.Position(lineNumber, text.length);
+			const range = new vscode.Range(start, end);
+
+			this._lines.push({
+				firstNonWhitespaceCharacterIndex: text.match(/^\s*/)[0].length,
+				isEmptyOrWhitespace: !/\S/.test(text),
+				lineNumber,
+				range,
+				rangeIncludingLineBreak: ws.endsWith('\r')
+					? range.with(start, end.translate(-1))
+					: range,
+				text
+			});
+		}
+
+		this._content = content;
+		this._eol = endOfLine;
+		this._fileName = uri.path.split('/').pop();
+		this._isClosed = false;
+		this._isDirty = false;
+		this._isUntitled = false;
+		this._languageId = languageId;
+		this._lineCount = lineCount;
+		this._uri = uri;
+		this._version = 0;
+	}
+
+	public get fileName(): string {
+		return this._fileName;
+	}
+
+	public get isUntitled(): boolean {
+		return this._isUntitled;
+	}
+
+	public get isDirty(): boolean {
+		return this._isDirty;
+	}
+
+	public get isClosed(): boolean {
+		return this._isClosed;
+	}
+
+	public get eol(): vscode.EndOfLine {
+		return this._eol;
+	}
+
+	public get uri(): vscode.Uri {
+		return this._uri;
+	}
+
+	public get languageId(): string {
+		return this._languageId;
+	}
+
+	public get version(): number {
+		return this._version;
+	}
+
+	public get lineCount() {
+		return this._lineCount;
+	}
+
+	public save(): Thenable<boolean> {
+		return Promise.resolve(false);
+	}
+
+	public lineAt(offset: number | vscode.Position): vscode.TextLine {
+		const lineNumber = typeof offset === 'object' ? offset.line : offset;
+		return this._lines[lineNumber];
+	}
+
+	public offsetAt(position: vscode.Position): number {
+		const lineOffsets = this._getLineOffsets();
+
+		if (position.line >= lineOffsets.length) {
+			return this._content.length;
+		} else if (position.line < 0) {
+			return 0;
+		}
+
+		const lineOffset = lineOffsets[position.line];
+		const nextLineOffset = position.line + 1 < lineOffsets.length
+			? lineOffsets[position.line + 1]
+			: this._content.length;
+
+		return Math.max(Math.min(lineOffset + position.character, nextLineOffset), lineOffset);
+	}
+
+	public positionAt(offset: number): vscode.Position {
+		offset = Math.max(Math.min(offset, this._content.length), 0);
+
+		const lineOffsets = this._getLineOffsets();
+		let low = 0;
+		let high = lineOffsets.length;
+		if (high === 0) {
+			return new vscode.Position(0, offset);
+		}
+		while (low < high) {
+			const mid = Math.floor((low + high) / 2);
+			if (lineOffsets[mid] > offset) {
+				high = mid;
+			} else {
+				low = mid + 1;
+			}
+		}
+		// low is the least x for which the line offset is larger than the current offset
+		// or array.length if no line offset is larger than the current offset
+		const line = low - 1;
+		return new vscode.Position(line, offset - lineOffsets[line]);
+	}
+
+	public getText(range?: vscode.Range): string {
+		if (range) {
+			const start = this.offsetAt(range.start);
+			const end = this.offsetAt(range.end);
+			return this._content.substring(start, end);
+		}
+		return this._content;
+	}
+
+	public getWordRangeAtPosition(position: vscode.Position, regex?: RegExp): vscode.Range {
+		const validPosition = this.validatePosition(position);
+		const line = this.lineAt(validPosition.line);
+
+		if (!regex) {
+			// use default when custom-regexp isn't provided
+			regex = getWordDefinitionFor(this._languageId);
+
+		} else if (regExpLeadsToEndlessLoop(regex)) {
+			// use default when custom-regexp is bad
+			throw new Error(`[getWordRangeAtPosition]: ignoring custom regexp '${regex.source}' because it matches the empty string.`);
+		}
+
+		const wordAtText = getWordAtText(
+			validPosition.character + 1,
+			ensureValidWordDefinition(regex),
+			line.text,
+			0
+		);
+
+		if (wordAtText) {
+			return new vscode.Range(
+				validPosition.line,
+				wordAtText.startColumn - 1,
+				validPosition.line,
+				wordAtText.endColumn - 1
+			);
+		}
+		return void 0;
+	}
+
+	public validateRange(range: vscode.Range): vscode.Range {
+		const validStart = this.validatePosition(range.start);
+		const validEnd = this.validatePosition(range.end);
+
+		if (validStart.isEqual(range.start) && validEnd.isEqual(range.end)) {
+			return range;
+		}
+
+		if (
+			range.start.line > range.end.line ||
+			(range.start.line === range.end.line && range.start.character > range.end.character)
+		) {
+			return new vscode.Range(range.end, range.start);
+		}
+
+		return new vscode.Range(validStart, validEnd);
+	}
+
+	public validatePosition(position: vscode.Position): vscode.Position {
+		if (this._lines.length === 0) {
+			return position.with(0, 0);
+		}
+
+		let { line, character } = position;
+		let hasChanged = false;
+
+		if (line < 0) {
+			line = 0;
+			character = 0;
+			hasChanged = true;
+		} else if (line >= this._lines.length) {
+			line = this._lines.length - 1;
+			character = this._lines[line].text.length;
+			hasChanged = true;
+		} else {
+			const maxCharacter = this._lines[line].text.length;
+			if (character < 0) {
+				character = 0;
+				hasChanged = true;
+			} else if (character > maxCharacter) {
+				character = maxCharacter;
+				hasChanged = true;
+			}
+		}
+
+		if (!hasChanged) {
+			return position;
+		}
+		return new vscode.Position(line, character);
+	}
+
+	private _getLineOffsets() {
+		if (this._lineOffsets === undefined) {
+			this._lineOffsets = computeLineOffsets(this._content, true);
+		}
+		return this._lineOffsets;
+	}
+
 }
 
 export interface DocumentServiceInterface {
-	readonly onDidChangeDocument: vscode.Event<LiteTextDocument>;
-	readonly onDidCreateDocument: vscode.Event<LiteTextDocument>;
+	readonly onDidChangeDocument: vscode.Event<vscode.TextDocument>;
+	readonly onDidCreateDocument: vscode.Event<vscode.TextDocument>;
 	readonly onDidDeleteDocument: vscode.Event<vscode.Uri>;
 
-	getAllDocuments(): Thenable<Iterable<LiteTextDocument>>;
-	getDocument(resource: vscode.Uri): Thenable<LiteTextDocument | undefined>;
+	getAllDocuments(): Thenable<Iterable<vscode.TextDocument>>;
+	getDocument(resource: vscode.Uri): Thenable<vscode.TextDocument | undefined>;
 }
 
 export class DocumentService extends Disposable implements DocumentServiceInterface {
-	private readonly _onDidChangeDocumentEmitter = this._register(new vscode.EventEmitter<LiteTextDocument>());
-	private readonly _onDidCreateDocumentEmitter = this._register(new vscode.EventEmitter<LiteTextDocument>());
+	private readonly _onDidChangeDocumentEmitter = this._register(new vscode.EventEmitter<vscode.TextDocument>());
+	private readonly _onDidCreateDocumentEmitter = this._register(new vscode.EventEmitter<vscode.TextDocument>());
 	private readonly _onDidDeleteDocumentEmitter = this._register(new vscode.EventEmitter<vscode.Uri>());
 
 	private _watcher: vscode.FileSystemWatcher | undefined;
@@ -63,10 +310,10 @@ export class DocumentService extends Disposable implements DocumentServiceInterf
 	public async getAllDocuments() {
 		const resources = await vscode.workspace.findFiles(this._config.include, this._config.exclude);
 		const docs = await Promise.all(resources.map(doc => this.getDocument(doc)));
-		return docs.filter((doc): doc is LiteTextDocument => !!doc);
+		return docs.filter((doc): doc is vscode.TextDocument => !!doc);
 	}
 
-	public async getDocument(resource: vscode.Uri): Promise<LiteTextDocument> {
+	public async getDocument(resource: vscode.Uri): Promise<vscode.TextDocument> {
 		const matchingDocuments = vscode.workspace.textDocuments.filter(function(document) {
 			return document.uri.toString(true) === resource.toString(true);
 		});
@@ -75,32 +322,16 @@ export class DocumentService extends Disposable implements DocumentServiceInterf
 		}
 
 		const text = await readFileText(resource);
+		const filename = resource.path.split('/').pop();
+		const point = contributorData.getLanguageDefinitionFromFilename(filename);
+		const languageId = point.id;
 
-		const lines: LiteTextLine[] = [];
-		const parts = text.split(/(\r?\n)/);
-		const lineCount = Math.floor(parts.length / 2) + 1;
-		for (let line = 0; line < lineCount; line++) {
-			lines.push({
-				text: parts[line * 2]
-			});
+		if (!getWordDefinitionFor(languageId)) {
+			const configuration = await contributorData.getLanguageConfigurationFromLanguageId(languageId);
+			setWordDefinitionFor(languageId, configuration.wordPattern || defaultWordPattern);
 		}
 
-		const filename = resource.path.split('/').pop();
-		const point = resolver.getLanguageDefinitionFromFilename(filename);
-		const languageId = point?.id;
-
-		return {
-			getText() {
-				return text;
-			},
-			languageId,
-			lineAt(index) {
-				return lines[index];
-			},
-			lineCount,
-			uri: resource,
-			version: 0
-		};
+		return new FullTextDocument(resource, languageId, text);
 	}
 
 	private ensureWatcher(): void {
@@ -134,4 +365,155 @@ export class DocumentService extends Disposable implements DocumentServiceInterf
 			}
 		}, this, this._disposables);
 	}
+}
+
+const CharCode = {
+	/**
+	 * The `\r` character.
+	 */
+	CarriageReturn: 13,
+	/**
+	 * The `\n` character.
+	 */
+	LineFeed: 10
+};
+
+function computeLineOffsets(text: string, isAtLineStart: boolean, textOffset = 0): number[] {
+	const result: number[] = isAtLineStart ? [textOffset] : [];
+
+	for (let i = 0; i < text.length; i++) {
+		const ch = text.charCodeAt(i);
+		if (ch === CharCode.CarriageReturn || ch === CharCode.LineFeed) {
+			if (ch === CharCode.CarriageReturn && i + 1 < text.length && text.charCodeAt(i + 1) === CharCode.LineFeed) {
+				i++;
+			}
+			result.push(textOffset + i + 1);
+		}
+	}
+
+	return result;
+}
+
+function ensureValidWordDefinition(wordDefinition?: RegExp | null): RegExp {
+	let result: RegExp = defaultWordPattern;
+
+	if (wordDefinition && (wordDefinition instanceof RegExp)) {
+		if (!wordDefinition.global) {
+			let flags = 'g';
+			if (wordDefinition.ignoreCase) {
+				flags += 'i';
+			}
+			if (wordDefinition.multiline) {
+				flags += 'm';
+			}
+			if (wordDefinition.unicode) {
+				flags += 'u';
+			}
+			result = new RegExp(wordDefinition.source, flags);
+		} else {
+			result = wordDefinition;
+		}
+	}
+
+	result.lastIndex = 0;
+
+	return result;
+}
+
+interface IWordAtPosition {
+	readonly word: string;
+	readonly startColumn: number;
+	readonly endColumn: number;
+}
+
+const getWordAtTextConfig = {
+	maxLen: 1000,
+	timeBudget: 150,
+	windowSize: 15
+};
+
+function getWordAtText(column: number, wordDefinition: RegExp, text: string, textOffset: number): IWordAtPosition | null {
+	if (text.length > getWordAtTextConfig.maxLen) {
+		// don't throw strings that long at the regexp
+		// but use a sub-string in which a word must occur
+		let start = column - getWordAtTextConfig.maxLen / 2;
+		if (start < 0) {
+			start = 0;
+		} else {
+			textOffset += start;
+		}
+		text = text.substring(start, column + getWordAtTextConfig.maxLen / 2);
+		return getWordAtText(column, wordDefinition, text, textOffset);
+	}
+
+	const t1 = Date.now();
+	const pos = column - 1 - textOffset;
+
+	let prevRegexIndex = -1;
+	let match: RegExpExecArray | null = null;
+
+	for (let i = 1; ; i++) {
+		// check time budget
+		if (Date.now() - t1 >= getWordAtTextConfig.timeBudget) {
+			break;
+		}
+
+		// reset the index at which the regexp should start matching, also know where it
+		// should stop so that subsequent search don't repeat previous searches
+		const regexIndex = pos - getWordAtTextConfig.windowSize * i;
+		wordDefinition.lastIndex = Math.max(0, regexIndex);
+		const thisMatch = _findRegexMatchEnclosingPosition(wordDefinition, text, pos, prevRegexIndex);
+
+		if (!thisMatch && match) {
+			// stop: we have something
+			break;
+		}
+
+		match = thisMatch;
+
+		// stop: searched at start
+		if (regexIndex <= 0) {
+			break;
+		}
+		prevRegexIndex = regexIndex;
+	}
+
+	if (match) {
+		const result = {
+			endColumn: textOffset + 1 + match.index + match[0].length,
+			startColumn: textOffset + 1 + match.index,
+			word: match[0],
+		};
+		wordDefinition.lastIndex = 0;
+		return result;
+	}
+
+	return null;
+}
+
+function _findRegexMatchEnclosingPosition(wordDefinition: RegExp, text: string, pos: number, stopPos: number): RegExpExecArray | null {
+	let match: RegExpExecArray | null;
+	while (match = wordDefinition.exec(text)) {
+		const matchIndex = match.index || 0;
+		if (matchIndex <= pos && wordDefinition.lastIndex >= pos) {
+			return match;
+		} else if (stopPos > 0 && matchIndex > stopPos) {
+			return null;
+		}
+	}
+	return null;
+}
+
+
+function regExpLeadsToEndlessLoop(regexp: RegExp): boolean {
+	// Exit early if it's one of these special cases which are meant to match
+	// against an empty string
+	if (regexp.source === '^' || regexp.source === '^$' || regexp.source === '$' || regexp.source === '^\\s*$') {
+		return false;
+	}
+
+	// We check against an empty string. If the regular expression doesn't advance
+	// (e.g. ends in an endless loop) it will match an empty string.
+	const match = regexp.exec('');
+	return !!(match && regexp.lastIndex === 0);
 }

--- a/src/services/document.ts
+++ b/src/services/document.ts
@@ -68,7 +68,7 @@ export class FullTextDocument implements vscode.TextDocument {
 				isEmptyOrWhitespace: !/\S/.test(text),
 				lineNumber,
 				range,
-				rangeIncludingLineBreak: ws.endsWith('\r')
+				rangeIncludingLineBreak: ws?.endsWith('\r')
 					? range.with(start, end.translate(-1))
 					: range,
 				text

--- a/src/services/outline.ts
+++ b/src/services/outline.ts
@@ -6,7 +6,6 @@ import { TextmateScopeSelector } from '../util/selectors';
 import { ServiceBase } from '../util/service';
 
 import type { ConfigData } from '../config';
-import type { LiteTextDocument } from './document';
 import type { TokenizerService, TextmateToken } from './tokenizer';
 
 const entitySelector = new TextmateScopeSelector('entity');
@@ -26,12 +25,12 @@ export class OutlineService extends ServiceBase<OutlineEntry[]> {
 		super();
 	}
 
-	public async lookup(document: LiteTextDocument, text: string): Promise<OutlineEntry | void> {
+	public async lookup(document: vscode.TextDocument, text: string): Promise<OutlineEntry | void> {
 		const outline = await this.fetch(document);
 		return outline.find(entry => entry.text === text);
 	}
 
-	public async parse(document: LiteTextDocument): Promise<OutlineEntry[]> {
+	public async parse(document: vscode.TextDocument): Promise<OutlineEntry[]> {
 		const outline: OutlineEntry[] = [];
 		const tokens = await this._tokenService.fetch(document);
 

--- a/src/services/tokenizer.ts
+++ b/src/services/tokenizer.ts
@@ -4,8 +4,8 @@ import * as vscodeTextmate from 'vscode-textmate';
 
 import { ServiceBase } from '../util/service';
 
+import type * as vscode from 'vscode';
 import type { Mutable } from 'type-fest';
-import type { LiteTextDocument, LiteTextLine } from './document';
 import type { ConfigData } from '../config';
 
 export interface TextmateToken extends Mutable<vscodeTextmate.IToken> {
@@ -38,7 +38,7 @@ export class TokenizerService extends ServiceBase<TextmateToken[]> {
 		super();
 	}
 
-	public async parse(document: LiteTextDocument): Promise<TextmateToken[]> {
+	public async parse(document: vscode.TextDocument): Promise<TextmateToken[]> {
 		const tokens: TextmateToken[] = [];
 
 		const state = this._states[document.uri.path] = {} as TextmateTokenizerState;
@@ -50,7 +50,7 @@ export class TokenizerService extends ServiceBase<TextmateToken[]> {
 		state.stack = 0;
 
 		for (let lineNumber = 0; lineNumber < document.lineCount; lineNumber++) {
-			const line: LiteTextLine = document.lineAt(lineNumber);
+			const line: vscode.TextLine = document.lineAt(lineNumber);
 			const lineResult = this._grammar.tokenizeLine(line.text, state.rule) as TextmateTokenizeLineResult;
 
 			for (const token of lineResult.tokens) {

--- a/src/util/service.ts
+++ b/src/util/service.ts
@@ -1,20 +1,21 @@
 'use strict';
 
+import type * as vscode from 'vscode';
+
 import * as crypto from './crypto';
-import type { LiteTextDocument } from '../services/document';
 
 const encoder = new TextEncoder();
 
 export interface ServiceInterface<T> {
-	fetch(document: LiteTextDocument): Promise<T>;
-	parse(document: LiteTextDocument): Promise<T>;
+	fetch(document: vscode.TextDocument): Promise<T>;
+	parse(document: vscode.TextDocument): Promise<T>;
 }
 
 export abstract class ServiceBase<T> {
 	private _cache: Record<string, Promise<T>> = {};
 	private _integrity: Record<string, string> = {};
 
-	public async fetch(document: LiteTextDocument | string): Promise<T> {
+	public async fetch(document: vscode.TextDocument | string): Promise<T> {
 		const filepath = typeof document === 'string' ? document : document.uri.path;
 		const hash = await hashify(document);
 
@@ -38,10 +39,10 @@ export abstract class ServiceBase<T> {
 		return output;
 	}
 
-	public abstract parse(document: LiteTextDocument | string): Promise<T>;
+	public abstract parse(document: vscode.TextDocument | string): Promise<T>;
 }
 
-async function hashify(document: LiteTextDocument | string): Promise<string> {
+async function hashify(document: vscode.TextDocument | string): Promise<string> {
 	const text = typeof document === 'string' ? document : document.getText();
 	if (crypto.node) {
 		const hash = crypto.node.createHash('sha256');

--- a/src/workspace-symbol.ts
+++ b/src/workspace-symbol.ts
@@ -6,7 +6,7 @@ import { Disposable } from './util/dispose';
 import { lazy } from './util/lazy';
 import type { Lazy } from './util/lazy';
 import type { TextmateDocumentSymbolProvider } from './document-symbol';
-import type { LiteTextDocument, DocumentService } from './services/document';
+import type { DocumentService } from './services/document';
 
 export class TextmateWorkspaceSymbolProvider extends Disposable implements vscode.WorkspaceSymbolProvider {
 	private _symbolCache = new Map<string, Lazy<Thenable<vscode.SymbolInformation[]>>>();
@@ -37,13 +37,13 @@ export class TextmateWorkspaceSymbolProvider extends Disposable implements vscod
 		}
 	}
 
-	private getSymbols(document: LiteTextDocument): Lazy<Thenable<vscode.SymbolInformation[]>> {
+	private getSymbols(document: vscode.TextDocument): Lazy<Thenable<vscode.SymbolInformation[]>> {
 		const provideDocumentSymbolInformation = this._documentSymbols.provideDocumentSymbolInformation
 			.bind(this._documentSymbols, document) as () => Promise<vscode.SymbolInformation[]>;
 		return lazy(provideDocumentSymbolInformation);
 	}
 
-	private onDidChangeDocument(document: LiteTextDocument) {
+	private onDidChangeDocument(document: vscode.TextDocument) {
 		this._symbolCache.set(document.uri.fsPath, this.getSymbols(document));
 	}
 

--- a/test/suite/providers/definition.test.ts
+++ b/test/suite/providers/definition.test.ts
@@ -89,10 +89,9 @@ async function definitionProviderResult() {
 	const results: DefinitionTestResult[][] = [];
 
 	for (const resource of samples) {
-		const skinnyDocument = await documentService.getDocument(resource);
-		const tokens = await tokenizer.fetch(skinnyDocument);
+		const document = await documentService.getDocument(resource);
+		const tokens = await tokenizer.fetch(document);
 
-		const document = await vscode.workspace.openTextDocument(resource);
 		const activeEditor = await vscode.window.showTextDocument(document);
 
 		const symbols = tokens.filter(isBaseClassReference);

--- a/test/suite/providers/folding.test.ts
+++ b/test/suite/providers/folding.test.ts
@@ -2,7 +2,7 @@
 
 import * as vscode from 'vscode';
 
-import { foldingRangeProviderPromise } from '../../util/factory';
+import { documentServicePromise, foldingRangeProviderPromise } from '../../util/factory';
 import { BASENAMES, getSampleFileUri } from '../../util/files';
 import { runSamplePass } from '../../util/bench';
 
@@ -35,6 +35,7 @@ suite('test/suite/folding.test.ts - TextmateFoldingRangeProvider class (src/fold
 });
 
 async function foldingRangeProviderResult() {
+	const documentService = await documentServicePromise;
 	const foldingRangeProvider = await foldingRangeProviderPromise;
 
 	const foldingContext = {};
@@ -44,7 +45,7 @@ async function foldingRangeProviderResult() {
 	const results: vscode.FoldingRange[][] = [];
 
 	for (const resource of samples) {
-		const document = await vscode.workspace.openTextDocument(resource);
+		const document = await documentService.getDocument(resource);
 
 		const folds = await foldingRangeProvider.provideFoldingRanges(document, foldingContext, cancelToken);
 

--- a/test/suite/services/document.test.ts
+++ b/test/suite/services/document.test.ts
@@ -7,12 +7,12 @@ import { documentServicePromise } from '../../util/factory';
 import { BASENAMES, getSampleFileUri } from '../../util/files';
 import { jsonify } from '../../util/jsonify';
 
-import type { LiteTextDocument } from '../../../src/services/document';
+import type { FullTextDocument } from '../../../src/services/document';
 
 suite('test/suite/document.test.ts - DocumentService class (src/services/document.ts)', function() {
 	this.timeout(5000);
 
-	test('LiteTextDocument.uri', async function() {
+	test('FullTextDocument.uri', async function() {
 		void vscode.window.showInformationMessage('DocumentService class (src/services/document.ts)');
 		const { actuals, expecteds, filenames, samples } = await documentServiceOutput();
 
@@ -23,7 +23,7 @@ suite('test/suite/document.test.ts - DocumentService class (src/services/documen
 		}
 	});
 
-	test('LiteTextDocument.lineCount', async function() {
+	test('FullTextDocument.lineCount', async function() {
 		const { actuals, expecteds, filenames, samples } = await documentServiceOutput();
 
 		for (let index = 0; index < samples.length; index++) {
@@ -33,7 +33,7 @@ suite('test/suite/document.test.ts - DocumentService class (src/services/documen
 		}
 	});
 
-	test('LiteTextDocument.lineAt(line: number)', async function() {
+	test('FullTextDocument.lineAt(line: number)', async function() {
 		const { actuals, expecteds, filenames, samples } = await documentServiceOutput();
 
 		for (let index = 0; index < samples.length; index++) {
@@ -54,7 +54,7 @@ async function documentServiceOutput() {
 	const samples = BASENAMES[globalThis.languageId].map(getSampleFileUri);
 
 	const expecteds: vscode.TextDocument[] = [];
-	const actuals: LiteTextDocument[] = [];
+	const actuals: vscode.TextDocument[] = [];
 	const filenames: string[] = [];
 
 	for (const resource of samples) {


### PR DESCRIPTION
## 🏗️ Pull Request

<!-- Fill the following checklist. -->
- [x] Used a clear / meaningful title for this pull request.
- [x] Tested the changes on your own grammar (on your projects).
- [x] Added / Edited tests to reflect changes (`test` folder).
- [x] Have read the **Contributing** part of the **README**.
- [x] Passed `npm test`.
- [x] I noted my changes in the pull request body and/or changelog.

<!-- Complete the following parts. -->

#### 👷🏾‍♀️ Fixes

<!-- List the issues that this fixes. -->
Related to #63.

#### Description

<!-- A clear & concise explanation of the pull and why it was opened. -->
Improve core API interop by using `vscode.TextDocument` mock.

#### What changes have you made?

- Generate `vscode.TextDocument` mocks for document service output.
- Switch `LiteTextDocument` to `vscode.TextDocument` across the package.

#### What tests have you completed?

- [x] Tested this in Visual Studio Code v1.95.1.
- [x] Tested this in Visual Studio Code Insiders v1.96.0.
- [x] Tested this for GitHub Codespaces v1.96.0.
- [x] Tested this in VSCodium v1.95.1.

#### Anything else worth mentioning?

<!-- Please help with the PR process. Remove this section if it is empty. -->
<!-- Leave any extra useful information or mention someone who is concerned. -->
Some performance testing would be useful.